### PR TITLE
[parsing:grimoirelab] Script, library and tests to parse GrimoireLab files (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ $ sortinghat load identities.json
 * SQLAlchemy >= 1.0.0
 * Jinja2 >= 2.7
 * python-dateutil >= 2.6
+* python-yaml >= 3.12
 
 You will also need a MySQL Python driver to connect with the database server. We recommend to use one these packages:
 

--- a/misc/grimoirelab2sh
+++ b/misc/grimoirelab2sh
@@ -18,6 +18,7 @@
 #
 # Authors:
 #     Luis Cañas-Díaz <lcanas@bitergia.com>
+#     Miguel Ángel Fernández Sánchez <mafesan@bitergia.com>
 #
 
 from __future__ import unicode_literals
@@ -41,7 +42,7 @@ def main():
     args = parse_args()
 
     try:
-        parser = parse_grimoirelab_file(args.identities, args.domain_employer,
+        parser = parse_grimoirelab_file(args.identities, args.organizations,
                                         args.source)
     except (IOError, UnicodeDecodeError, InvalidFormatError) as e:
         raise RuntimeError(str(e))
@@ -54,14 +55,15 @@ def main():
     except IOError as e:
         raise RuntimeError(str(e))
 
+
 def parse_args():
     """Parse arguments from the command line"""
 
     parser = argparse.ArgumentParser(description=GRIMOIRELAB2SH_DESC_MSG)
 
     parser.add_argument('-i', '--identities', type=argparse.FileType('r'),
-                         help='GrimoireLab profiles/identities mapping file')
-    parser.add_argument('-d', '--domain-employer', dest='domain_employer',
+                        help='GrimoireLab profiles/identities mapping file')
+    parser.add_argument('-d', '--organizations', dest='organizations',
                         type=argparse.FileType('r'),
                         help='GrimoireLab domain to employer mapping file')
     parser.add_argument('-s', '--source', dest='source', required=True,
@@ -72,24 +74,17 @@ def parse_args():
 
     args = parser.parse_args()
 
-    if not (args.identities or args.domain_employer):
+    if not (args.identities or args.organizations):
         parser.error('No input file passed, add --domain-employer or --identities')
 
     return args
 
 
-def parse_grimoirelab_file(identities, domain_employer, source):
+def parse_grimoirelab_file(identities, organizations, source):
     """Parse GrimoireLab JSON file"""
 
-    if identities:
-        content_id = read_file(identities)
-    else:
-        content_id = None
-
-    if domain_employer:
-        content_org = read_file(domain_employer)
-    else:
-        content_org = None
+    content_id = read_file(identities) if identities else None
+    content_org = read_file(organizations) if organizations else None
 
     try:
         parser = GrimoireLabParser(content_id, content_org, source=source)
@@ -112,9 +107,8 @@ def to_json(uidentities, organizations, source):
         uuid = uidentity.uuid
 
         uid = uidentity.to_dict()
-        #uid['identities'].sort(key=lambda x: x['email'])
 
-        enrollments = [rol.to_dict() \
+        enrollments = [rol.to_dict()
                        for rol in uidentity.enrollments]
         uid['enrollments'] = enrollments
 
@@ -122,21 +116,22 @@ def to_json(uidentities, organizations, source):
 
     for organization in organizations:
         domains = [{'domain': dom.domain,
-                    'is_top': dom.is_top_domain} \
+                    'is_top': dom.is_top_domain}
                    for dom in organization.domains]
         domains.sort(key=lambda x: x['domain'])
 
         orgs[organization.name] = domains
 
     # Generate JSON file
-    obj = {'time' : str(datetime.datetime.now()),
-           'source' : source,
-           'blacklist' : [],
-           'organizations' : orgs,
-           'uidentities' : uids}
+    obj = {'time': str(datetime.datetime.now()),
+           'source': source,
+           'blacklist': [],
+           'organizations': orgs,
+           'uidentities': uids}
 
     return json.dumps(obj, default=json_encoder,
                       indent=4, sort_keys=True)
+
 
 def json_encoder(obj):
     """Default JSON encoder"""
@@ -146,10 +141,11 @@ def json_encoder(obj):
     else:
         return json.JSONEncoder.default(obj)
 
+
 def read_file(f):
-    if sys.version_info[0] >= 3: # Python 3
+    if sys.version_info[0] >= 3:  # Python 3
         content = f.read()
-    else: # Python 2
+    else:  # Python 2
         content = f.read().decode('UTF-8')
     return content
 

--- a/misc/grimoirelab2sh
+++ b/misc/grimoirelab2sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Luis Cañas-Díaz <lcanas@bitergia.com>
+#
+
+from __future__ import unicode_literals
+
+import argparse
+import datetime
+import json
+import sys
+
+from sortinghat.exceptions import InvalidFormatError
+from sortinghat.parsing.grimoirelab import GrimoireLabParser
+
+
+GRIMOIRELAB2SH_DESC_MSG = \
+"""Export identities information from GrimoireLab files to Sorting Hat JSON format."""
+
+
+def main():
+    """Export identities information from GrimoireLab files"""
+
+    args = parse_args()
+
+    try:
+        parser = parse_grimoirelab_file(args.identities, args.domain_employer,
+                                        args.source)
+    except (IOError, UnicodeDecodeError, InvalidFormatError) as e:
+        raise RuntimeError(str(e))
+
+    j = to_json(parser.identities, parser.organizations, args.source)
+
+    try:
+        args.outfile.write(j)
+        args.outfile.write('\n')
+    except IOError as e:
+        raise RuntimeError(str(e))
+
+def parse_args():
+    """Parse arguments from the command line"""
+
+    parser = argparse.ArgumentParser(description=GRIMOIRELAB2SH_DESC_MSG)
+
+    parser.add_argument('-i', '--identities', type=argparse.FileType('r'),
+                         help='GrimoireLab profiles/identities mapping file')
+    parser.add_argument('-d', '--domain-employer', dest='domain_employer',
+                        type=argparse.FileType('r'),
+                        help='GrimoireLab domain to employer mapping file')
+    parser.add_argument('-s', '--source', dest='source', required=True,
+                        help='name of the source')
+    parser.add_argument('-o', '--outfile', nargs='?', type=argparse.FileType('w'),
+                        default=sys.stdout,
+                        help='Sorting Hat JSON output filename')
+
+    args = parser.parse_args()
+
+    if not (args.identities or args.domain_employer):
+        parser.error('No input file passed, add --domain-employer or --identities')
+
+    return args
+
+
+def parse_grimoirelab_file(identities, domain_employer, source):
+    """Parse GrimoireLab JSON file"""
+
+    if identities:
+        content_id = read_file(identities)
+    else:
+        content_id = None
+
+    if domain_employer:
+        content_org = read_file(domain_employer)
+    else:
+        content_org = None
+
+    try:
+        parser = GrimoireLabParser(content_id, content_org, source=source)
+    except ValueError:
+        s = "Error: Empty input file(s)\n"
+        sys.stdout.write(s)
+        sys.exit(0)
+
+    return parser
+
+
+def to_json(uidentities, organizations, source):
+    """Convert unique identities and organizations to Sorting Hat JSON format"""
+
+    uids = {}
+    orgs = {}
+
+    # Convert to dict objects
+    for uidentity in uidentities:
+        uuid = uidentity.uuid
+
+        uid = uidentity.to_dict()
+        #uid['identities'].sort(key=lambda x: x['email'])
+
+        enrollments = [rol.to_dict() \
+                       for rol in uidentity.enrollments]
+        uid['enrollments'] = enrollments
+
+        uids[uuid] = uid
+
+    for organization in organizations:
+        domains = [{'domain': dom.domain,
+                    'is_top': dom.is_top_domain} \
+                   for dom in organization.domains]
+        domains.sort(key=lambda x: x['domain'])
+
+        orgs[organization.name] = domains
+
+    # Generate JSON file
+    obj = {'time' : str(datetime.datetime.now()),
+           'source' : source,
+           'blacklist' : [],
+           'organizations' : orgs,
+           'uidentities' : uids}
+
+    return json.dumps(obj, default=json_encoder,
+                      indent=4, sort_keys=True)
+
+def json_encoder(obj):
+    """Default JSON encoder"""
+
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    else:
+        return json.JSONEncoder.default(obj)
+
+def read_file(f):
+    if sys.version_info[0] >= 3: # Python 3
+        content = f.read()
+    else: # Python 2
+        content = f.read().decode('UTF-8')
+    return content
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        s = "\n\nReceived Ctrl-C or other break signal. Exiting.\n"
+        sys.stdout.write(s)
+        sys.exit(0)
+    except RuntimeError as e:
+        s = "Error: %s\n" % str(e)
+        sys.stderr.write(s)
+        sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setup(name="sortinghat",
         'sqlalchemy>=1.0.0',
         'jinja2',
         'python-dateutil>=2.6.0',
-        'pandas>=0.15'
+        'pandas>=0.15',
+        'pyyaml>=3.12'
       ],
       zip_safe=False
     )

--- a/sortinghat/parsing/grimoirelab.py
+++ b/sortinghat/parsing/grimoirelab.py
@@ -1,0 +1,355 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Luis Cañas-Díaz <sduenas@bitergia.com>
+#
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import itertools
+import re
+import datetime
+import yaml
+
+from ..db.model import MIN_PERIOD_DATE, MAX_PERIOD_DATE, \
+    UniqueIdentity, Identity, Enrollment, Organization, Domain, Profile
+from ..exceptions import InvalidFormatError
+
+PERCEVAL_BACKENDS = ['askbot','bugzilla','bugzillarest','confluence','discourse',
+                    'dockerhub','gerrit','git','github','gmane','hyperkitty','jenkins',
+                    'jira','mbox','mediawiki','meetup','nntp','phabricator','pipermail',
+                    'redmine','rss','slack','stackexchange','supybot','telegram']
+
+
+class GrimoireLabParser(object):
+    """Parse identities and organizations using GrimoireLab format.
+
+    The GrimoireLab data format is a YAML stream that contains information
+    about unique identities and organizations.
+
+    The unique identities are stored in an object named 'uidentities'.
+    The keys of this object are the UUID of the unique identities.
+    Each unique identity object stores a list of identities and
+    enrollments.
+
+    Organizations are stored in 'organizations' object. Its keys
+    are the name of the organizations and each organization object is
+    related to a list of domains.
+
+    :param stream: stream to parse
+
+    :raises InvalidFormatError: raised when the format of the stream is
+        not valid.
+    """
+
+    EMAIL_ADDRESS_REGEX = r"^(?P<email>[^\s@]+@[^\s@.]+\.[^\s@]+)$"
+
+
+    def __init__(self, identities=None, domain_employer=None,
+                 source='grimoirelab'):
+        self._identities = {}
+        self._organizations = {}
+        self.source = source
+
+        if not (identities or domain_employer):
+            raise ValueError('Null identities and organization streams')
+
+        self.__parse(identities, domain_employer)
+
+    @property
+    def identities(self):
+        uids = [u for u in self._identities.values()]
+        uids.sort(key=lambda u: u.uuid)
+        return uids
+
+    @property
+    def organizations(self):
+        orgs = [o for o in self._organizations.values()]
+        orgs.sort(key=lambda o: o.name)
+        return orgs
+
+    def __parse(self, identities_stream, domain_employer_stream):
+        """Parse GrimoireLab stream"""
+        if domain_employer_stream:
+            self.__parse_organizations(domain_employer_stream)
+
+        if identities_stream:
+            self.__parse_identities(identities_stream)
+
+    def __parse_identities(self, stream):
+        """Parse identities using GrimoireLab format.
+
+        The GrimoireLab identities format is a YAML document following a
+        schema similar to the example below. More information available
+        at https://github.com/bitergia/identities
+
+        - profile:
+            name: Vivek K.
+            is_bot: false
+          github:
+            - vsekhark
+          email:
+            - vivek@****.com
+          enrollments:
+            - organization: Community
+              start: 1900-01-01
+              end: 2100-01-01
+
+        :parse json: YAML object to parse
+
+        :raise InvalidFormatError: raised when the format of the YAML is
+            not valid.
+        """
+        def __create_sh_identities(name, emails, yaml_entry):
+            """Create SH identities based on name, emails and backens data in yaml_entry"""
+            my_ids = []
+            my_ids.append(Identity(name=name, source=self.source))
+
+            # FIXME we should encourage our users to add email or usernames
+            # and if not returning at least a WARNING
+            if emails:
+                for m in emails:
+                    my_ids.append(Identity(email=m, source=self.source))
+
+            for pb in PERCEVAL_BACKENDS:
+
+                if pb not in yaml_entry:
+                    continue
+
+                for username in yaml_entry[pb]:
+                    identity = Identity(username=username, source=pb)
+                    my_ids.append(identity)
+
+            return my_ids
+
+
+        yaml = self.__load_yml(stream)
+
+        try:
+            for yid in yaml:
+                profile = yid['profile']
+                if profile is None:
+                    raise AttributeError('profile')
+
+                #we want the KeyError if name is missing
+                name = yid['profile']['name']
+                is_bot = profile.get('is_bot', False)
+
+                emails = yid.get('email', None)
+                enrollments = yid.get('enrollments', None)
+
+                first_email, first_username = self.__first_email_username(yid)
+                uuid = self.__compose_uuid(name, first_email, first_username)
+
+                uid = UniqueIdentity(uuid=uuid)
+
+                prf = Profile(name=name, is_bot=is_bot)
+                uid.profile = prf
+
+                # now it is time to add the identities for name, emails and backends
+                sh_identities = __create_sh_identities(name, emails, yid)
+                uid.identities += sh_identities
+
+                if enrollments:
+                    affiliations = self.__parse_affiliations_yml(enrollments, uuid)
+                    uid.enrollments += affiliations
+
+                self._identities[uuid] = uid
+
+        except KeyError as e:
+            msg = "invalid GrimoireLab yaml format. Attribute %s not found" % e.args
+            raise InvalidFormatError(cause=msg)
+
+    def __parse_organizations(self, stream):
+        """Parse GrimoireLab organizations.
+
+        The GrimoireLab organizations format is a YAML element stored
+        under the "organizations" key. The next example shows the
+        structure of the document:
+
+        - organizations:
+            Bitergia:
+                - bitergia.com
+                - support.bitergia.com
+                - biterg.io
+            LibreSoft:
+                - libresoft.es
+
+        :param json: YAML object to parse
+
+        :raises InvalidFormatError: raised when the format of the YAML is
+            not valid.
+        """
+        if not stream:
+            return
+
+        yaml = self.__load_yml(stream)
+
+        try:
+            for element in yaml:
+                name = self.__encode(element['organization'])
+
+                if not name:
+                    msg = "invalid GrimoireLab yaml format. Empty organization name"
+                    raise InvalidFormatError(cause=msg)
+
+                o = Organization(name=name)
+
+                if 'domains' in element:
+                    if isinstance(element['domains'], list):
+                        for dom in element['domains']:
+                            if dom:
+                                d = Domain(domain=dom, is_top_domain=False)
+                                o.domains.append(d)
+                            else:
+                                msg = "invalid GrimoireLab yaml format. Empty domain name for organization %s" % name
+                                raise InvalidFormatError(cause=msg)
+                    else:
+                        msg = "invalid GrimoireLab yaml format. List of elements expected for organization %s" % name
+                        raise InvalidFormatError(cause=msg)
+                self._organizations[name] = o
+
+        except KeyError as e:
+            msg = "invalid GrimoireLab yaml format. Attribute %s not found" % e.args
+            raise InvalidFormatError(cause=msg)
+
+        except TypeError as e:
+            msg = "invalid GrimoireLab yaml format. %s" % e.args
+            raise InvalidFormatError(cause=msg)
+
+    def __parse_affiliations_yml(self, affiliations, uuid):
+        """Parse identity's affiliations from a yaml dict."""
+        enrollments = []
+
+        for aff in affiliations:
+            name = self.__encode(aff['organization'])
+            if not name:
+                msg = "invalid GrimoireLab yaml format. Empty organization name"
+                raise InvalidFormatError(cause=msg)
+
+            # we trust the Organization name included in the identities file
+            org = Organization(name=name)
+
+            if org is None:
+                continue
+
+            if 'start' in aff:
+                start_date = self.__force_datetime(aff['start'])
+            else:
+                start_date = MIN_PERIOD_DATE
+
+            if 'end' in aff:
+                end_date = self.__force_datetime(aff['end'])
+            else:
+                end_date = MAX_PERIOD_DATE
+
+            enrollment = Enrollment(start=start_date, end=end_date,
+                                    organization=org)
+            enrollments.append(enrollment)
+
+        self.__validate_enrollment_periods(enrollments)
+
+        return enrollments
+
+    def __force_datetime(self, obj):
+        """Converts ojb to time.datetime.datetime
+
+        YAML parsing returns either date or datetime object depending
+        on how the date is written. YYYY-MM-DD will return a date and
+        YYYY-MM-DDThh:mm:ss will return a datetime
+
+        :param obj: date or datetime object
+        """
+        if isinstance(obj,datetime.datetime):
+            return obj
+
+        t = datetime.time(0,0)
+        return datetime.datetime.combine(obj, t)
+
+    def __load_yml(self, stream):
+        """Load yml stream into a dict object """
+        try:
+            return yaml.load(stream)
+        except ValueError as e:
+            cause = "invalid yml format. %s" % str(e)
+            raise InvalidFormatError(cause=cause)
+
+    def __encode(self, s):
+        import sys
+
+        if sys.version_info[0] >= 3: # Python 3
+            return s if s else None
+        else: # Python 2
+            if type(s) is str:
+                return s.encode('UTF-8') if s else None
+            else:
+                return s
+
+    def __compose_uuid(self, name, email, username):
+        """Composes a uuid string as result of the concatenation of name and (email and/or username)"""
+        uuid = ''
+        uuid += name
+        if email:
+            uuid += email
+        if username:
+            uuid += username
+        return uuid
+
+    def __first_email_username(self, yaml_identity):
+        """Returns first email and first username found in the YAML identity"""
+        first_email = None
+        first_username = None
+        emails = yaml_identity.get('email', None)
+
+        if emails:
+            first_email = self.__validate_email(emails[0])
+
+        for pb in PERCEVAL_BACKENDS:
+            if pb in yaml_identity:
+                first_username = yaml_identity[pb][0]
+                break
+
+        #either first_email or first_username must exist
+        if (first_email is None) and (first_username is None):
+            msg = "invalid GrimoireLab yaml format. At least email or user account must be included"
+            raise InvalidFormatError(cause=msg)
+        return (first_email, first_username)
+
+    def __validate_email(self, email):
+        """Checks if a string looks like an email address"""
+        e = re.match(self.EMAIL_ADDRESS_REGEX, email, re.UNICODE)
+        if e:
+            return email
+        else:
+            msg = "invalid GrimoireLab yaml format. Invalid email address: " + str(email)
+            raise InvalidFormatError(cause=msg)
+
+    def __validate_enrollment_periods(self, enrollments):
+        """Check for overlapped periods in the enrollments"""
+        for a, b in itertools.combinations(enrollments, 2):
+
+            max_start = max(a.start, b.start)
+            min_end = min(a.end, b.end)
+
+            if max_start < min_end:
+                msg = "invalid GrimoireLab enrollment dates. " \
+                "Organization dates overlap."
+                raise InvalidFormatError(cause=msg)
+
+        return enrollments

--- a/tests/data/grimoirelab_invalid.yml
+++ b/tests/data/grimoirelab_invalid.yml
@@ -1,0 +1,26 @@
+- profile:
+    name: J. Manrique Lopez de la Fuente
+  enrollments:
+    - organization: Bitergia
+      start: 2013-01-01
+  github:
+    - jsmanrique
+  email:
+    - jsmanrique@bitergia.com
+
+# this is another entry
+- profile:
+    name: Luis Cañas-Díaz
+  enrollments:
+    - organization: Bitergia
+      start: 2012-01-01
+  github:
+    - sanacl
+  email:
+    - lcanas@bitergia.com
+
+# and another one for bots
+profile:
+    is_bot: true
+  email:
+    - owlbot@bitergia.com

--- a/tests/data/grimoirelab_invalid_datetime.yml
+++ b/tests/data/grimoirelab_invalid_datetime.yml
@@ -1,0 +1,30 @@
+- profile:
+    name: J. Manrique Lopez de la Fuente
+  # the enrollments below overlap
+  enrollments:
+    - organization: Example
+      start: 1980-01-01
+    - organization: Bitergia
+      start: 2011-01-01
+      end: 2015-06-01
+  github:
+    - jsmanrique
+  email:
+    - jsmanrique@bitergia.com
+
+# this is another entry
+- profile:
+    name: Luis Cañas-Díaz
+  enrollments:
+    - organization: Bitergia
+      start: 2012-01-01
+  github:
+    - sanacl
+  email:
+    - lcanas@bitergia.com
+
+# and another one for bots
+- profile:
+    is_bot: true
+  email:
+    - owlbot@bitergia.com

--- a/tests/data/grimoirelab_invalid_email.yml
+++ b/tests/data/grimoirelab_invalid_email.yml
@@ -21,6 +21,7 @@
 
 # and another one for bots
 - profile:
+    name: Owl Bot
     is_bot: true
   email:
     - owlbot@bitergia.com

--- a/tests/data/grimoirelab_invalid_email.yml
+++ b/tests/data/grimoirelab_invalid_email.yml
@@ -1,0 +1,26 @@
+- profile:
+    name: J. Manrique Lopez de la Fuente
+  enrollments:
+    - organization: Bitergia
+      start: 2013-01-01
+  github:
+    - jsmanrique
+  email:
+    - jsmanrique@bitergia.com
+
+# this is another entry
+- profile:
+    name: Luis Cañas-Díaz
+  enrollments:
+    - organization: Bitergia
+      start: 2012-01-01
+  github:
+    - sanacl
+  email:
+    - lcanas__at__bitergia.com
+
+# and another one for bots
+- profile:
+    is_bot: true
+  email:
+    - owlbot@bitergia.com

--- a/tests/data/grimoirelab_invalid_missing_accounts.yml
+++ b/tests/data/grimoirelab_invalid_missing_accounts.yml
@@ -1,0 +1,27 @@
+- profile:
+    name: J. Manrique Lopez de la Fuente
+  enrollments:
+    - organization: Bitergia
+      start: 2013-01-01
+  github:
+    - jsmanrique
+  jira:
+    - jsm
+  email:
+    - jsmanrique@bitergia.com
+
+# this is another entry
+- profile:
+    name: Luis Cañas-Díaz
+  enrollments:
+    - organization: GSyC/LibreSoft
+      start: 2003-01-01
+      end: 2011-12-31
+    - organization: Bitergia
+      start: 2012-01-01T00:00:00
+
+# and another one for bots
+- profile:
+    is_bot: true
+  email:
+    - owlbot@bitergia.com

--- a/tests/data/grimoirelab_invalid_missing_organization_name.yml
+++ b/tests/data/grimoirelab_invalid_missing_organization_name.yml
@@ -1,0 +1,35 @@
+# invalid entry
+- profile:
+    name: J. Manrique Lopez de la Fuente
+  enrollments:
+    - organization: 
+      start: 2013-01-01
+  github:
+    - jsmanrique
+  jira:
+    - jsm
+  email:
+    - jsmanrique@bitergia.com
+
+# valid entry
+- profile:
+    name: Luis Cañas-Díaz
+  enrollments:
+    - organization: GSyC/LibreSoft
+      start: 2003-01-01
+      end: 2011-12-31
+    - organization: Bitergia
+      start: 2012-01-01T00:00:00
+  github:
+    - sanacl
+  irc:
+    - lcanas
+  email:
+    - lcanas@bitergia.com
+
+# valid entry
+- profile:
+    name: Owl Bot
+    is_bot: true
+  email:
+    - owlbot@bitergia.com

--- a/tests/data/grimoirelab_invalid_missing_profile.yml
+++ b/tests/data/grimoirelab_invalid_missing_profile.yml
@@ -1,0 +1,32 @@
+# wrong entry without profile
+- enrollments:
+    - organization: Bitergia
+      start: 2013-01-01
+  github:
+    - jsmanrique
+  jira:
+    - jsm
+  email:
+    - jsmanrique@bitergia.com
+
+# this is another entry
+- profile:
+    name: Luis Cañas-Díaz
+  enrollments:
+    - organization: GSyC/LibreSoft
+      start: 2003-01-01
+      end: 2011-12-31
+    - organization: Bitergia
+      start: 2012-01-01T00:00:00
+  github:
+    - sanacl
+  irc:
+    - lcanas
+  email:
+    - lcanas@bitergia.com
+
+# and another one for bots
+- profile:
+    is_bot: true
+  email:
+    - owlbot@bitergia.com

--- a/tests/data/grimoirelab_invalid_missing_profile_name_isbot.yml
+++ b/tests/data/grimoirelab_invalid_missing_profile_name_isbot.yml
@@ -1,0 +1,35 @@
+# wrong entry with profile without name and is_bot
+- profile:
+    country: Spain
+  enrollments:
+    - organization: Bitergia
+      start: 2013-01-01
+  github:
+    - jsmanrique
+  jira:
+    - jsm
+  email:
+    - jsmanrique@bitergia.com
+
+# valid entry
+- profile:
+    name: Luis Cañas-Díaz
+  enrollments:
+    - organization: GSyC/LibreSoft
+      start: 2003-01-01
+      end: 2011-12-31
+    - organization: Bitergia
+      start: 2012-01-01T00:00:00
+  github:
+    - sanacl
+  irc:
+    - lcanas
+  email:
+    - lcanas@bitergia.com
+
+# valid entry
+- profile:
+    name: Owl Bot
+    is_bot: true
+  email:
+    - owlbot@bitergia.com

--- a/tests/data/grimoirelab_invalid_structure.yml
+++ b/tests/data/grimoirelab_invalid_structure.yml
@@ -1,0 +1,25 @@
+- profile:
+    name: J. Manrique Lopez de la Fuente
+  enrollments:
+    - organization: Bitergia
+      start: 2013-01-01
+  github:
+    - jsmanrique
+  email:
+    - jsmanrique@bitergia.com
+
+# this is another entry
+- name: Luis Cañas-Díaz
+  enrollments:
+    - organization: Bitergia
+      start: 2012-01-01
+  github:
+    - sanacl
+  email:
+    - lcanas@bitergia.com
+
+# and another one for bots
+- profile:
+    is_bot: true
+  email:
+    - owlbot@bitergia.com

--- a/tests/data/grimoirelab_orgs_invalid_domains_list_with_empty_value.yml
+++ b/tests/data/grimoirelab_orgs_invalid_domains_list_with_empty_value.yml
@@ -1,0 +1,13 @@
+- organization: Bitergia
+  domains:
+    - bitergia.com
+    - 
+- organization: Example
+  domains:
+    - example.com
+    - example.org
+    - example.net
+- organization: GSyC/LibreSoft
+  domains:
+    - libresoft.es
+    - gsyc.es

--- a/tests/data/grimoirelab_orgs_invalid_empty_domains.yml
+++ b/tests/data/grimoirelab_orgs_invalid_empty_domains.yml
@@ -1,0 +1,11 @@
+- organization: Bitergia
+  domains:
+- organization: Example
+  domains:
+    - example.com
+    - example.org
+    - example.net
+- organization: GSyC/LibreSoft
+  domains:
+    - libresoft.es
+    - gsyc.es

--- a/tests/data/grimoirelab_orgs_invalid_key_with_no_value.yml
+++ b/tests/data/grimoirelab_orgs_invalid_key_with_no_value.yml
@@ -1,0 +1,12 @@
+- organization: 
+  domains:
+    - bitergia.com
+- organization: Example
+  domains:
+    - example.com
+    - example.org
+    - example.net
+- organization: GSyC/LibreSoft
+  domains:
+    - libresoft.es
+    - gsyc.es

--- a/tests/data/grimoirelab_orgs_invalid_missing_key.yml
+++ b/tests/data/grimoirelab_orgs_invalid_missing_key.yml
@@ -1,0 +1,11 @@
+- domains: 
+    - bitergia.com
+- organization: Example
+  domains:
+    - example.com
+    - example.org
+    - example.net
+- organization: GSyC/LibreSoft
+  domains:
+    - libresoft.es
+    - gsyc.es

--- a/tests/data/grimoirelab_orgs_invalid_wrong_domains_type.yml
+++ b/tests/data/grimoirelab_orgs_invalid_wrong_domains_type.yml
@@ -1,0 +1,11 @@
+- organization: Bitergia
+  domains: bitergia.com
+- organization: Example
+  domains:
+    - example.com
+    - example.org
+    - example.net
+- organization: GSyC/LibreSoft
+  domains:
+    - libresoft.es
+    - gsyc.es

--- a/tests/data/grimoirelab_orgs_valid.yml
+++ b/tests/data/grimoirelab_orgs_valid.yml
@@ -1,0 +1,13 @@
+- organization: Bitergia
+  domains:
+    - bitergia.com
+    - bitergia.net
+- organization: Example
+  domains:
+    - example.com
+    - example.org
+    - example.net
+- organization: GSyC/LibreSoft
+  domains:
+    - libresoft.es
+    - gsyc.es

--- a/tests/data/grimoirelab_valid.yml
+++ b/tests/data/grimoirelab_valid.yml
@@ -1,0 +1,35 @@
+# valid entry
+- profile:
+    name: J. Manrique Lopez de la Fuente
+  enrollments:
+    - organization: Bitergia
+      start: 2013-01-01
+  github:
+    - jsmanrique
+  jira:
+    - jsm
+  email:
+    - jsmanrique@bitergia.com
+
+# valid entry
+- profile:
+    name: Luis Cañas-Díaz
+  enrollments:
+    - organization: GSyC/LibreSoft
+      start: 2003-01-01
+      end: 2011-12-31
+    - organization: Bitergia
+      start: 2012-01-01T00:00:00
+  github:
+    - sanacl
+  irc:
+    - lcanas
+  email:
+    - lcanas@bitergia.com
+
+# valid entry
+- profile:
+    name: Owl Bot
+    is_bot: true
+  email:
+    - owlbot@bitergia.com

--- a/tests/test_parser_grimoirelab.py
+++ b/tests/test_parser_grimoirelab.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Luis Cañas-Díaz <lcanas@bitergia.com>
+#
+
+from __future__ import unicode_literals
+
+import datetime
+import sys
+import unittest
+
+if not '..' in sys.path:
+    sys.path.insert(0, '..')
+
+from sortinghat.db.model import UniqueIdentity, Identity, Enrollment, Organization, Domain
+from sortinghat.exceptions import InvalidFormatError
+from sortinghat.parsing.grimoirelab import GrimoireLabParser
+
+class TestBaseCase(unittest.TestCase):
+    """Defines common methods for unit tests"""
+
+    def read_file(self, filename):
+        if sys.version_info[0] >= 3: # Python 3
+            with open(filename, 'r', encoding='UTF-8') as f:
+                content = f.read()
+        else: # Python 2
+            with open(filename, 'r') as f:
+                content = f.read().decode('UTF-8')
+        return content
+
+
+class TestGrimoreLabParser(TestBaseCase):
+    """Test GrimoireLabParser parser"""
+
+    def test_call_with_empty_parameters(self):
+        """Check if library accepts a call with None parameters"""
+        with self.assertRaises(ValueError):
+            GrimoireLabParser(None, None)
+
+    def test_identities_parser(self):
+        """Check whether it parses a valid identities file"""
+
+        stream_ids = self.read_file('data/grimoirelab_valid.yml')
+
+        parser = GrimoireLabParser(stream_ids)
+
+        # Parsed unique identities
+        uids = parser.identities
+        self.assertEqual(len(uids), 3)
+
+        # J. Manrique Lopez de la Fuente
+        uid = uids[0]
+        self.assertIsInstance(uid, UniqueIdentity)
+        self.assertEqual(uid.uuid, 'J. Manrique Lopez de la Fuentejsmanrique@bitergia.comjsmanrique')
+        self.assertFalse(uid.profile.is_bot)
+        self.assertEqual(uid.profile.name,'J. Manrique Lopez de la Fuente')
+
+        ids = uid.identities
+        self.assertEqual(len(ids), 4)
+
+        id0 = ids[0]
+        self.assertIsInstance(id0, Identity)
+        self.assertEqual(id0.name, 'J. Manrique Lopez de la Fuente')
+        self.assertEqual(id0.email, None)
+        self.assertEqual(id0.username, None)
+        self.assertEqual(id0.source, 'grimoirelab')
+        self.assertEqual(id0.uuid, None)
+
+        id1 = ids[1]
+        self.assertIsInstance(id1, Identity)
+        self.assertEqual(id1.name, None)
+        self.assertEqual(id1.email, 'jsmanrique@bitergia.com')
+        self.assertEqual(id1.username, None)
+        self.assertEqual(id1.source, 'grimoirelab')
+        self.assertEqual(id1.uuid, None)
+
+        id1 = ids[2]
+        self.assertIsInstance(id1, Identity)
+        self.assertEqual(id1.name, None)
+        self.assertEqual(id1.email, None)
+        self.assertEqual(id1.username, 'jsmanrique')
+        self.assertEqual(id1.source, 'github')
+        self.assertEqual(id1.uuid, None)
+
+        id1 = ids[3]
+        self.assertIsInstance(id1, Identity)
+        self.assertEqual(id1.name, None)
+        self.assertEqual(id1.email, None)
+        self.assertEqual(id1.username, 'jsm')
+        self.assertEqual(id1.source, 'jira')
+        self.assertEqual(id1.uuid, None)
+
+        # Luis Cañas-Díaz
+        uid = uids[1]
+        self.assertIsInstance(uid, UniqueIdentity)
+        self.assertEqual(uid.uuid, 'Luis Cañas-Díazlcanas@bitergia.comsanacl')
+        self.assertFalse(uid.profile.is_bot)
+        self.assertEqual(uid.profile.name,'Luis Cañas-Díaz')
+
+        self.assertIsInstance(uid, UniqueIdentity)
+
+        ids = uid.identities
+        self.assertEqual(len(ids), 3)
+
+        id0 = ids[0]
+        self.assertIsInstance(id0, Identity)
+        self.assertEqual(id0.name, 'Luis Cañas-Díaz')
+        self.assertEqual(id0.email, None)
+        self.assertEqual(id0.username, None)
+        self.assertEqual(id0.source, 'grimoirelab')
+        self.assertEqual(id0.uuid, None)
+
+        id1 = ids[1]
+        self.assertIsInstance(id1, Identity)
+        self.assertEqual(id1.name, None)
+        self.assertEqual(id1.email, 'lcanas@bitergia.com')
+        self.assertEqual(id1.username, None)
+        self.assertEqual(id1.source, 'grimoirelab')
+        self.assertEqual(id1.uuid, None)
+
+        id1 = ids[2]
+        self.assertIsInstance(id1, Identity)
+        self.assertEqual(id1.name, None)
+        self.assertEqual(id1.email, None)
+        self.assertEqual(id1.username, 'sanacl')
+        self.assertEqual(id1.source, 'github')
+        self.assertEqual(id1.uuid, None)
+
+        # owlbot
+        uid = uids[2]
+        self.assertIsInstance(uid, UniqueIdentity)
+        self.assertEqual(uid.uuid, 'Owl Botowlbot@bitergia.com')
+        self.assertTrue(uid.profile.is_bot)
+
+        self.assertIsInstance(uid, UniqueIdentity)
+
+        ids = uid.identities
+        self.assertEqual(len(ids), 2)
+
+        id0 = ids[0]
+        self.assertIsInstance(id0, Identity)
+        self.assertEqual(id0.name, 'Owl Bot')
+        self.assertEqual(id0.email, None)
+        self.assertEqual(id0.username, None)
+        self.assertEqual(id0.source, 'grimoirelab')
+        self.assertEqual(id0.uuid, None)
+
+        id0 = ids[1]
+        self.assertIsInstance(id0, Identity)
+        self.assertEqual(id0.name, None)
+        self.assertEqual(id0.email, 'owlbot@bitergia.com')
+        self.assertEqual(id0.username, None)
+        self.assertEqual(id0.source, 'grimoirelab')
+        self.assertEqual(id0.uuid, None)
+
+    def test_organizations_parser(self):
+        """Check whether it parses a valid organizations file"""
+
+        stream_orgs = self.read_file('data/grimoirelab_orgs_valid.yml')
+
+        parser = GrimoireLabParser(domain_employer=stream_orgs)
+
+        # Parsed organizations
+        orgs = parser.organizations
+
+        self.assertEqual(len(orgs), 3)
+
+        # Bitergia entries
+        org = orgs[0]
+        self.assertIsInstance(org, Organization)
+        self.assertEqual(org.name, 'Bitergia')
+
+        doms = org.domains
+        self.assertEqual(len(doms), 2)
+
+        dom = doms[0]
+        self.assertIsInstance(dom, Domain)
+        self.assertEqual(dom.domain, 'bitergia.com')
+        self.assertEqual(dom.is_top_domain, False)
+
+        dom = doms[1]
+        self.assertIsInstance(dom, Domain)
+        self.assertEqual(dom.domain, 'bitergia.net')
+        self.assertEqual(dom.is_top_domain, False)
+
+        # Example entries
+        org = orgs[1]
+        self.assertIsInstance(org, Organization)
+        self.assertEqual(org.name, 'Example')
+
+        doms = org.domains
+        self.assertEqual(len(doms), 3)
+
+        dom = doms[0]
+        self.assertIsInstance(dom, Domain)
+        self.assertEqual(dom.domain, 'example.com')
+        self.assertEqual(dom.is_top_domain, False)
+
+        dom = doms[1]
+        self.assertIsInstance(dom, Domain)
+        self.assertEqual(dom.domain, 'example.org')
+        self.assertEqual(dom.is_top_domain, False)
+
+        dom = doms[2]
+        self.assertIsInstance(dom, Domain)
+        self.assertEqual(dom.domain, 'example.net')
+        self.assertEqual(dom.is_top_domain, False)
+
+        # GSyC/Libresof entries
+        org = orgs[2]
+        self.assertIsInstance(org, Organization)
+        self.assertEqual(org.name, 'GSyC/LibreSoft')
+
+        doms = org.domains
+        self.assertEqual(len(doms), 2)
+
+        dom = doms[0]
+        self.assertIsInstance(dom, Domain)
+        self.assertEqual(dom.domain, 'libresoft.es')
+        self.assertEqual(dom.is_top_domain, False)
+
+        dom = doms[1]
+        self.assertIsInstance(dom, Domain)
+        self.assertEqual(dom.domain, 'gsyc.es')
+        self.assertEqual(dom.is_top_domain, False)
+
+    def test_enrollments_parser(self):
+        """Check whether enrollments are correctly parsed"""
+
+        stream_ids = self.read_file('data/grimoirelab_valid.yml')
+
+        parser = GrimoireLabParser(stream_ids)
+
+        # Parsed unique identities
+        uids = parser.identities
+
+        # J. Manrique Lopez de la Fuente
+        uid = uids[0]
+        rol = uid.enrollments[0]
+        self.assertIsInstance(rol, Enrollment)
+        self.assertEqual(rol.organization.name, 'Bitergia')
+        self.assertEqual(rol.start, datetime.datetime(2013, 1, 1, 0, 0))
+        self.assertEqual(rol.end, datetime.datetime(2100, 1, 1, 0, 0))
+
+        # Luis Cañas-Díaz
+        uid = uids[1]
+        rol = uid.enrollments[0]
+        self.assertIsInstance(rol, Enrollment)
+        self.assertEqual(rol.organization.name, 'GSyC/LibreSoft')
+        self.assertEqual(rol.start, datetime.datetime(2003, 1, 1, 0, 0))
+        self.assertEqual(rol.end, datetime.datetime(2011, 12, 31, 0, 0))
+
+        rol = uid.enrollments[1]
+        self.assertIsInstance(rol, Enrollment)
+        self.assertEqual(rol.organization.name, 'Bitergia')
+        self.assertEqual(rol.start, datetime.datetime(2012, 1, 1, 0, 0))
+        self.assertEqual(rol.end, datetime.datetime(2100, 1, 1, 0, 0))
+
+    def test_not_valid_organizations_stream(self):
+        """Check whether it parses invalid organizations files"""
+
+        # empty domains
+        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_empty_domains.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(domain_employer=stream_orgs)
+
+        # one of the domains is empty
+        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_domains_list_with_empty_value.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(domain_employer=stream_orgs)
+
+        # domains got a string instead of a list
+        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_wrong_domains_type.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(domain_employer=stream_orgs)
+
+        # organization key missing
+        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_missing_key.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(domain_employer=stream_orgs)
+
+        # organization key with empty value
+        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_key_with_no_value.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(domain_employer=stream_orgs)
+
+    def test_not_valid_identities_stream(self):
+        """Check whether it parses invalid identities files"""
+
+        stream_ids = self.read_file('data/grimoirelab_invalid_email.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(stream_ids)
+
+        stream_ids = self.read_file('data/grimoirelab_invalid_structure.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(stream_ids)
+
+        stream_ids = self.read_file('data/grimoirelab_invalid_missing_accounts.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(stream_ids)
+
+        stream_ids = self.read_file('data/grimoirelab_invalid_missing_profile_name_isbot.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(stream_ids)
+
+        stream_ids = self.read_file('data/grimoirelab_invalid_missing_profile.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(stream_ids)
+
+        stream_ids = self.read_file('data/grimoirelab_invalid_missing_organization_name.yml')
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(stream_ids)
+
+    def test_not_valid_enrollments_parser(self):
+        """Check whether data from both identites and organizations files is coherent"""
+
+        stream_ids = self.read_file('data/grimoirelab_invalid_datetime.yml')
+        stream_orgs = self.read_file('data/grimoirelab_orgs_valid.yml')
+
+        with self.assertRaises(InvalidFormatError):
+            GrimoireLabParser(stream_ids, stream_orgs)
+
+
+if __name__ == "__main__":
+    unittest.main(buffer=False, exit=False)

--- a/tests/test_parser_grimoirelab.py
+++ b/tests/test_parser_grimoirelab.py
@@ -18,6 +18,7 @@
 #
 # Authors:
 #     Luis Cañas-Díaz <lcanas@bitergia.com>
+#     Miguel Ángel Fernández Sánchez <mafesan@bitergia.com>
 #
 
 from __future__ import unicode_literals
@@ -26,21 +27,22 @@ import datetime
 import sys
 import unittest
 
-if not '..' in sys.path:
+if '..' not in sys.path:
     sys.path.insert(0, '..')
 
 from sortinghat.db.model import UniqueIdentity, Identity, Enrollment, Organization, Domain
 from sortinghat.exceptions import InvalidFormatError
 from sortinghat.parsing.grimoirelab import GrimoireLabParser
 
+
 class TestBaseCase(unittest.TestCase):
     """Defines common methods for unit tests"""
 
     def read_file(self, filename):
-        if sys.version_info[0] >= 3: # Python 3
+        if sys.version_info[0] >= 3:  # Python 3
             with open(filename, 'r', encoding='UTF-8') as f:
                 content = f.read()
-        else: # Python 2
+        else:  # Python 2
             with open(filename, 'r') as f:
                 content = f.read().decode('UTF-8')
         return content
@@ -51,6 +53,7 @@ class TestGrimoreLabParser(TestBaseCase):
 
     def test_call_with_empty_parameters(self):
         """Check if library accepts a call with None parameters"""
+
         with self.assertRaises(ValueError):
             GrimoireLabParser(None, None)
 
@@ -68,9 +71,8 @@ class TestGrimoreLabParser(TestBaseCase):
         # J. Manrique Lopez de la Fuente
         uid = uids[0]
         self.assertIsInstance(uid, UniqueIdentity)
-        self.assertEqual(uid.uuid, 'J. Manrique Lopez de la Fuentejsmanrique@bitergia.comjsmanrique')
         self.assertFalse(uid.profile.is_bot)
-        self.assertEqual(uid.profile.name,'J. Manrique Lopez de la Fuente')
+        self.assertEqual(uid.profile.name, 'J. Manrique Lopez de la Fuente')
 
         ids = uid.identities
         self.assertEqual(len(ids), 4)
@@ -110,9 +112,8 @@ class TestGrimoreLabParser(TestBaseCase):
         # Luis Cañas-Díaz
         uid = uids[1]
         self.assertIsInstance(uid, UniqueIdentity)
-        self.assertEqual(uid.uuid, 'Luis Cañas-Díazlcanas@bitergia.comsanacl')
         self.assertFalse(uid.profile.is_bot)
-        self.assertEqual(uid.profile.name,'Luis Cañas-Díaz')
+        self.assertEqual(uid.profile.name, 'Luis Cañas-Díaz')
 
         self.assertIsInstance(uid, UniqueIdentity)
 
@@ -146,7 +147,6 @@ class TestGrimoreLabParser(TestBaseCase):
         # owlbot
         uid = uids[2]
         self.assertIsInstance(uid, UniqueIdentity)
-        self.assertEqual(uid.uuid, 'Owl Botowlbot@bitergia.com')
         self.assertTrue(uid.profile.is_bot)
 
         self.assertIsInstance(uid, UniqueIdentity)
@@ -175,7 +175,7 @@ class TestGrimoreLabParser(TestBaseCase):
 
         stream_orgs = self.read_file('data/grimoirelab_orgs_valid.yml')
 
-        parser = GrimoireLabParser(domain_employer=stream_orgs)
+        parser = GrimoireLabParser(organizations=stream_orgs)
 
         # Parsed organizations
         orgs = parser.organizations
@@ -278,54 +278,54 @@ class TestGrimoreLabParser(TestBaseCase):
 
         # empty domains
         stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_empty_domains.yml')
-        with self.assertRaises(InvalidFormatError):
-            GrimoireLabParser(domain_employer=stream_orgs)
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+List of elements expected for organization Bitergia$'):
+            GrimoireLabParser(organizations=stream_orgs)
 
         # one of the domains is empty
         stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_domains_list_with_empty_value.yml')
-        with self.assertRaises(InvalidFormatError):
-            GrimoireLabParser(domain_employer=stream_orgs)
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+Empty domain name for organization Bitergia$'):
+            GrimoireLabParser(organizations=stream_orgs)
 
         # domains got a string instead of a list
         stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_wrong_domains_type.yml')
-        with self.assertRaises(InvalidFormatError):
-            GrimoireLabParser(domain_employer=stream_orgs)
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+List of elements expected for organization Bitergia$'):
+            GrimoireLabParser(organizations=stream_orgs)
 
         # organization key missing
         stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_missing_key.yml')
-        with self.assertRaises(InvalidFormatError):
-            GrimoireLabParser(domain_employer=stream_orgs)
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+Attribute organization not found$'):
+            GrimoireLabParser(organizations=stream_orgs)
 
         # organization key with empty value
         stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_key_with_no_value.yml')
-        with self.assertRaises(InvalidFormatError):
-            GrimoireLabParser(domain_employer=stream_orgs)
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+Empty organization name$'):
+            GrimoireLabParser(organizations=stream_orgs)
 
     def test_not_valid_identities_stream(self):
         """Check whether it parses invalid identities files"""
 
         stream_ids = self.read_file('data/grimoirelab_invalid_email.yml')
-        with self.assertRaises(InvalidFormatError):
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+Invalid email address: lcanas__at__bitergia.com$'):
             GrimoireLabParser(stream_ids)
 
         stream_ids = self.read_file('data/grimoirelab_invalid_structure.yml')
-        with self.assertRaises(InvalidFormatError):
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+Attribute profile not found$'):
             GrimoireLabParser(stream_ids)
 
         stream_ids = self.read_file('data/grimoirelab_invalid_missing_accounts.yml')
-        with self.assertRaises(InvalidFormatError):
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+Attribute name not found$'):
             GrimoireLabParser(stream_ids)
 
         stream_ids = self.read_file('data/grimoirelab_invalid_missing_profile_name_isbot.yml')
-        with self.assertRaises(InvalidFormatError):
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+Attribute name not found$'):
             GrimoireLabParser(stream_ids)
 
         stream_ids = self.read_file('data/grimoirelab_invalid_missing_profile.yml')
-        with self.assertRaises(InvalidFormatError):
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+Attribute profile not found$'):
             GrimoireLabParser(stream_ids)
 
         stream_ids = self.read_file('data/grimoirelab_invalid_missing_organization_name.yml')
-        with self.assertRaises(InvalidFormatError):
+        with self.assertRaisesRegexp(InvalidFormatError, '^.+Empty organization name$'):
             GrimoireLabParser(stream_ids)
 
     def test_not_valid_enrollments_parser(self):


### PR DESCRIPTION
Address changes in PR #81 from @sanacl proposed by @sduenas.

Moreover, it was necessary to add some changes:

- In `sortinghat/parsing/grimoirelab.py`: as functions `__compose_uuid` and `__first_email_username` have been removed, now the variable `uuid` has the value of an incremental counter (`yid_counter`)

- In `tests/test_parser_grimoirelab.py`, when a `InvalidFormatError` exception raises, now it is used `assertRaisesRegex` function, which needs as a second parameter a regular expression for checking the exception message. 

- There was a wrong test, `data/grimoirelab_invalid_email.yml`. This was not checked in `sortinghat/parsing/grimoirelab.py` and the yml was bad formed also, so the exception never raised. Now there is a call to the function `__validate_email` and the yml has been corrected.


**Original PR #81 by @sanacl :** 

Script, library and tests to parse GrimoireLab files

With these changes, Sorting Hat will be able to import GrimoireLab
identity and organizations files converting them to Sorting Hat
format. The GrimoireLab format v1 is detailed at [https://github.com/Bitergia/identities](https://github.com/Bitergia/identities)

Changes add a script misc/grimoirelab2sh to convert GrimoireLab
identities and organization files into Sorting Hat format. Also add
the library used by the script and 7 test cases.