### PR TITLE
[cmd:load] Update profile information when loading identities

### DIFF
--- a/sortinghat/cmd/load.py
+++ b/sortinghat/cmd/load.py
@@ -274,8 +274,6 @@ class Load(Command):
             stored_uuid = self.__load_identities(uidentity.identities, stored_uuid,
                                                  verbose)
 
-            # The profile will be loaded when the stored unique identity
-            # does not have any one.
             try:
                 self.__load_profile(uidentity.profile, stored_uuid, verbose)
             except Exception as e:
@@ -368,14 +366,12 @@ class Load(Command):
 
         uid = api.unique_identities(self.db, uuid)[0]
 
-        if uid.profile:
-            self.log("-- profile already available for %s. Not updated" % uuid, verbose)
-            return
-
         if profile:
             self.__create_profile(profile, uuid, verbose)
-        else:
+        elif not uid.profile:
             self.__create_profile_from_identities(uid.identities, uuid, verbose)
+        else:
+            self.log("-- empty profile given for %s. Not updated" % uuid, verbose)
 
     def __create_profile(self, profile, uuid, verbose):
         """Create profile information from a profile object"""

--- a/tests/test_cmd_load.py
+++ b/tests/test_cmd_load.py
@@ -572,15 +572,13 @@ class TestLoadIdentities(TestLoadCaseBase):
         uid = uids[1]
         self.assertEqual(uid.uuid, '2371a34a0ac65fbd9d631464ee41d583ec0e1e88')
 
-        # The profile was not updated because it was already available
+        # The profile is updated because a new one was given
         prf = uid.profile
         self.assertEqual(prf.uuid, '2371a34a0ac65fbd9d631464ee41d583ec0e1e88')
-        self.assertEqual(prf.name, 'John Smith')
-        self.assertEqual(prf.email, None)
-        self.assertEqual(prf.is_bot, False)
-        self.assertEqual(prf.country_code, 'US')
-        self.assertEqual(prf.country.code, 'US')
-        self.assertEqual(prf.country.name, 'United States of America')
+        self.assertEqual(prf.name, None)
+        self.assertEqual(prf.email, 'jsmith@example.com')
+        self.assertEqual(prf.is_bot, True)
+        self.assertEqual(prf.country, None)
 
         ids = self.sort_identities(uid.identities)
         self.assertEqual(len(ids), 3)


### PR DESCRIPTION
So far, profile information was set only the first time a unique
identity was loaded. With this change, it will be updated only
when the given profile is not empty.

It fixes #90 