### PR TITLE
Substitute sort for sort_values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(name="sortinghat",
         'sqlalchemy>=1.0.0',
         'jinja2',
         'python-dateutil>=2.6.0',
-        'pandas>=0.15',
+        'pandas>=0.17',
         'pyyaml>=3.12'
       ],
       zip_safe=False

--- a/sortinghat/matcher.py
+++ b/sortinghat/matcher.py
@@ -238,7 +238,7 @@ def _match_with_pandas(filtered, matcher):
         return []
 
     df = pandas.DataFrame(data)
-    df = df.sort(['uuid'])
+    df = df.sort_values(['uuid'])
 
     cdfs = []
     criteria = matcher.matching_criteria()


### PR DESCRIPTION
DataFrame.sort() is no longer available in recent versions of pandas.
Since 0.17.0, sort_values is the function to use in this context
https://stackoverflow.com/questions/19332171/difference-between-sort-values-and-sort-index
Upgraded dependency on pandas accordingly.