### PR TITLE
Strict match

### DIFF
--- a/sortinghat/matcher.py
+++ b/sortinghat/matcher.py
@@ -33,9 +33,10 @@ class IdentityMatcher(object):
 
        - 'blacklist' : list of entries to ignore during the matching process
        - 'sources' : only match the identities from these sources
+       - 'strict' : strict matching (i.e, well-formed email addresses);
+          `True` by default
     """
     def __init__(self, **kwargs):
-
         self._kwargs = kwargs
         blacklist = self._kwargs.get('blacklist', None)
         sources = self._kwargs.get('sources', None)
@@ -52,6 +53,8 @@ class IdentityMatcher(object):
             self.sources.sort()
         else:
             self.sources = None
+
+        self.strict = self._kwargs.get('strict', True)
 
     def match(self, a, b):
         """Abstract method used to determine if both unique identities are the same.
@@ -117,7 +120,8 @@ class FilteredIdentity(object):
                }
 
 
-def create_identity_matcher(matcher='default', blacklist=None, sources=None):
+def create_identity_matcher(matcher='default', blacklist=None, sources=None,
+                            strict=True):
     """Create an identity matcher of the given type.
 
     Factory function that creates an identity matcher object of the type
@@ -127,6 +131,7 @@ def create_identity_matcher(matcher='default', blacklist=None, sources=None):
     :param matcher: type of the matcher
     :param blacklist: list of entries to ignore while matching
     :param sources: only match the identities from these sources
+    :param strict: strict matching (i.e, well-formed email addresses)
 
     :returns: a identity matcher object of the given type
 
@@ -140,7 +145,7 @@ def create_identity_matcher(matcher='default', blacklist=None, sources=None):
 
     klass = matching.SORTINGHAT_IDENTITIES_MATCHERS[matcher]
 
-    return klass(blacklist=blacklist, sources=sources)
+    return klass(blacklist=blacklist, sources=sources, strict=strict)
 
 
 def match(uidentities, matcher, fastmode=False):
@@ -306,7 +311,12 @@ def _build_matches(matches, uuids, no_filtered, fastmode=False):
     result += no_filtered
     result.sort(key=len, reverse=True)
 
-    return result
+    sresult = []
+    for r in result:
+        r.sort(key=lambda id_: id_.uuid)
+        sresult.append(r)
+
+    return sresult
 
 
 def _calculate_matches_closures(groups):

--- a/sortinghat/matching/email.py
+++ b/sortinghat/matching/email.py
@@ -51,15 +51,18 @@ class EmailMatcher(IdentityMatcher):
     Simple unique identities matcher.
 
     This matcher only produces a positive result when two identities
-    from each unique identity share the same email address. It also
-    returns a positive match when the uuid on both unique identities is equal.
+    from each unique identity share the same email address. When `strict`
+    is set, the email must be well-formed. It also returns a positive
+    match when the uuid on both unique identities is equal.
 
     :param blacklist: list of entries to ignore during the matching process
     :param sources: only match the identities from these sources
+    :param strict: strict matching with well-formed email addresses
     """
-    def __init__(self, blacklist=None, sources=None):
+    def __init__(self, blacklist=None, sources=None, strict=True):
         super(EmailMatcher, self).__init__(blacklist=blacklist,
-                                           sources=sources)
+                                           sources=sources,
+                                           strict=strict)
         self.email_pattern = re.compile(EMAIL_ADDRESS_REGEX)
 
     def match(self, a, b):
@@ -157,8 +160,11 @@ class EmailMatcher(IdentityMatcher):
             if self.sources and id_.source.lower() not in self.sources:
                 continue
 
-            if self._check_email(id_.email):
-                email = id_.email.lower()
+            if self.strict:
+                if self._check_email(id_.email):
+                    email = id_.email.lower()
+            else:
+                email = id_.email.lower() if id_.email else None
 
             if email:
                 fid = EmailIdentity(id_.id, id_.uuid, email)

--- a/sortinghat/matching/email_name.py
+++ b/sortinghat/matching/email_name.py
@@ -60,14 +60,17 @@ class EmailNameMatcher(IdentityMatcher):
        - identities share the same email address
        - name field is composed by "firstname lastname" and both are
          equal; i.e: "John Smith" and "J Smith Rae" are valid name fields;
-         "jonhsmith" are "j.smith" not valid
+         "jonhsmith" are "j.smith" not valid. This rigorous validation is
+         only done when `strict` mode is set to `True`.
 
     :param blacklist: list of entries to ignore during the matching process
     :param sources: only match the identities from these sources
+    :param strict: strict matching with well-formed email addresses and names
     """
-    def __init__(self, blacklist=None, sources=None):
+    def __init__(self, blacklist=None, sources=None, strict=True):
         super(EmailNameMatcher, self).__init__(blacklist=blacklist,
-                                               sources=sources)
+                                               sources=sources,
+                                               strict=strict)
         self.email_pattern = re.compile(EMAIL_ADDRESS_REGEX)
         self.name_pattern = re.compile(NAME_REGEX)
 
@@ -174,10 +177,14 @@ class EmailNameMatcher(IdentityMatcher):
             if self._check_blacklist(id_):
                 continue
 
-            if self._check_pattern(self.email_pattern, id_.email):
-                email = id_.email.lower()
-            if self._check_pattern(self.name_pattern, id_.name):
-                name = id_.name.lower()
+            if self.strict:
+                if self._check_pattern(self.email_pattern, id_.email):
+                    email = id_.email.lower()
+                if self._check_pattern(self.name_pattern, id_.name):
+                    name = id_.name.lower()
+            else:
+                email = id_.email.lower() if id_.email else None
+                name = id_.name.lower() if id_.name else None
 
             if email or name:
                 fid = EmailNameIdentity(id_.id, id_.uuid,

--- a/sortinghat/matching/github.py
+++ b/sortinghat/matching/github.py
@@ -57,10 +57,12 @@ class GitHubMatcher(IdentityMatcher):
 
     :param blacklist: list of entries to ignore during the matching process
     :param sources: only match the identities from these sources
+    :param strict: not used by this matcher
     """
-    def __init__(self, blacklist=None, sources=None):
+    def __init__(self, blacklist=None, sources=None, strict=True):
         super(GitHubMatcher, self).__init__(blacklist=blacklist,
-                                            sources=sources)
+                                            sources=sources,
+                                            strict=strict)
 
     def match(self, a, b):
         """Determine if two unique identities are the same.

--- a/sortinghat/matching/username.py
+++ b/sortinghat/matching/username.py
@@ -54,10 +54,12 @@ class UsernameMatcher(IdentityMatcher):
 
     :param blacklist: list of entries to ignore during the matching process
     :param sources: only match the identities from these sources
+    :param strict: not used by this matcher
     """
-    def __init__(self, blacklist=None, sources=None):
+    def __init__(self, blacklist=None, sources=None, strict=True):
         super(UsernameMatcher, self).__init__(blacklist=blacklist,
-                                              sources=sources)
+                                              sources=sources,
+                                              strict=strict)
 
     def match(self, a, b):
         """Determine if two unique identities are the same.

--- a/tests/data/sortinghat_no_strict_valid.json
+++ b/tests/data/sortinghat_no_strict_valid.json
@@ -1,0 +1,32 @@
+{
+    "source": null,
+    "time": "2017-11-16 17:13:00",
+    "blacklist": [
+    ],
+    "organizations": {
+    },
+    "uidentities": {
+        "e8284285566fdc1f41c8a22bb84a295fc3c4cbb3": {
+            "enrollments": [
+            ],
+            "identities": [
+                {
+                    "email": "jsmith@example",
+                    "id": "e8284285566fdc1f41c8a22bb84a295fc3c4cbb3",
+                    "name": null,
+                    "source": "scm",
+                    "username": null,
+                    "uuid": "e8284285566fdc1f41c8a22bb84a295fc3c4cbb3"
+                }
+            ],
+            "profile": {
+                "country": null,
+                "email": "jsmith@example.com",
+                "name": null,
+                "is_bot": true,
+                "uuid": "e8284285566fdc1f41c8a22bb84a295fc3c4cbb3"
+            },
+            "uuid": "e8284285566fdc1f41c8a22bb84a295fc3c4cbb3"
+        }
+    }
+}

--- a/tests/test_cmd_unify.py
+++ b/tests/test_cmd_unify.py
@@ -45,8 +45,8 @@ UNIFY_SOURCES_OUTPUT = """Unique identity f30dc6a71730e37f03c7e27379febb219f7918
 Total unique identities processed: 6
 Total matches: 1
 Total unique identities after merging: 5"""
-UNIFY_EMAIL_NAME_OUTPUT = """Unique identity 178315df7941fc76a6ffb06fd5b00f6932ad9c41 merged on 400fdfaab5918d1b7e0e0efba4797abdc378bd7d
-Unique identity 880b3dfcb3a08712e5831bddc3dfe81fc5d7b331 merged on 400fdfaab5918d1b7e0e0efba4797abdc378bd7d
+UNIFY_EMAIL_NAME_OUTPUT = """Unique identity 400fdfaab5918d1b7e0e0efba4797abdc378bd7d merged on 178315df7941fc76a6ffb06fd5b00f6932ad9c41
+Unique identity 880b3dfcb3a08712e5831bddc3dfe81fc5d7b331 merged on 178315df7941fc76a6ffb06fd5b00f6932ad9c41
 Unique identity f30dc6a71730e37f03c7e27379febb219f7918de merged on 9cb28b6fb034393bbe4749081e0da6cc5a715b85
 Total unique identities processed: 6
 Total matches: 3

--- a/tests/test_cmd_unify.py
+++ b/tests/test_cmd_unify.py
@@ -45,6 +45,13 @@ UNIFY_SOURCES_OUTPUT = """Unique identity f30dc6a71730e37f03c7e27379febb219f7918
 Total unique identities processed: 6
 Total matches: 1
 Total unique identities after merging: 5"""
+UNIFY_NO_STRICT_OUTPUT = """Unique identity 9cb28b6fb034393bbe4749081e0da6cc5a715b85 merged on 54806f99212ac5de67684dabda6db139fc6507ee
+Unique identity f30dc6a71730e37f03c7e27379febb219f7918de merged on 54806f99212ac5de67684dabda6db139fc6507ee
+Unique identity 400fdfaab5918d1b7e0e0efba4797abdc378bd7d merged on 178315df7941fc76a6ffb06fd5b00f6932ad9c41
+Unique identity 880b3dfcb3a08712e5831bddc3dfe81fc5d7b331 merged on 178315df7941fc76a6ffb06fd5b00f6932ad9c41
+Total unique identities processed: 6
+Total matches: 4
+Total unique identities after merging: 2"""
 UNIFY_EMAIL_NAME_OUTPUT = """Unique identity 400fdfaab5918d1b7e0e0efba4797abdc378bd7d merged on 178315df7941fc76a6ffb06fd5b00f6932ad9c41
 Unique identity 880b3dfcb3a08712e5831bddc3dfe81fc5d7b331 merged on 178315df7941fc76a6ffb06fd5b00f6932ad9c41
 Unique identity f30dc6a71730e37f03c7e27379febb219f7918de merged on 9cb28b6fb034393bbe4749081e0da6cc5a715b85
@@ -54,6 +61,7 @@ Total unique identities after merging: 3"""
 UNIFY_EMPTY_OUTPUT = """Total unique identities processed: 0
 Total matches: 0
 Total unique identities after merging: 0"""
+
 
 UNIFY_MATCHING_ERROR = "Error: mock identity matcher is not supported"
 
@@ -106,6 +114,14 @@ class TestUnifyCommand(TestUnifyCaseBase):
         self.assertEqual(code, CMD_SUCCESS)
         output = sys.stdout.getvalue().strip()
         self.assertEqual(output, UNIFY_DEFAULT_OUTPUT)
+
+    def test_unify_no_strict(self):
+        """Test command with no strict mode active"""
+
+        code = self.cmd.run('--no-strict-matching', '--matching', 'email-name')
+        self.assertEqual(code, CMD_SUCCESS)
+        output = sys.stdout.getvalue().strip()
+        self.assertEqual(output, UNIFY_NO_STRICT_OUTPUT)
 
     def test_unify_sources_list(self):
         """Test command with a sources list"""
@@ -203,6 +219,22 @@ class TestUnify(TestUnifyCaseBase):
 
         output = sys.stdout.getvalue().strip()
         self.assertEqual(output, UNIFY_DEFAULT_OUTPUT)
+
+    def test_unify_no_strict(self):
+        """Test unify method with no strict mode set"""
+
+        before = api.unique_identities(self.db)
+        self.assertEqual(len(before), 6)
+
+        code = self.cmd.unify(matching='email-name',
+                              no_strict_matching=True)
+        self.assertEqual(code, CMD_SUCCESS)
+
+        after = api.unique_identities(self.db)
+        self.assertEqual(len(after), 2)
+
+        output = sys.stdout.getvalue().strip()
+        self.assertEqual(output, UNIFY_NO_STRICT_OUTPUT)
 
     def test_unify_with_blacklist(self):
         """Test unify method using a blacklist"""

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -82,6 +82,17 @@ class TestCreateIdentityMatcher(unittest.TestCase):
         self.assertIsInstance(matcher, IdentityMatcher)
         self.assertEqual(len(matcher.sources), 3)
 
+    def test_identity_matcher_instance_with_strict(self):
+        """Test if the factory function adds the strict mode to the matcher instance"""
+
+        matcher = create_identity_matcher('default')
+        self.assertIsInstance(matcher, IdentityMatcher)
+        self.assertEqual(matcher.strict, True)
+
+        matcher = create_identity_matcher('default', strict=False)
+        self.assertIsInstance(matcher, IdentityMatcher)
+        self.assertEqual(matcher.strict, False)
+
     def test_not_supported_matcher(self):
         """Check if an exception is raised when the given matcher type is not supported"""
 
@@ -126,6 +137,15 @@ class TestIdentityMatcher(unittest.TestCase):
         m = IdentityMatcher(sources=sources)
 
         self.assertListEqual(m.sources, ['git', 'github', 'jira'])
+
+    def test_strict_mode(self):
+        """Test strict mode value"""
+
+        m = IdentityMatcher()
+        self.assertEqual(m.strict, True)
+
+        m = IdentityMatcher(strict=False)
+        self.assertEqual(m.strict, False)
 
 
 class TestMatch(unittest.TestCase):
@@ -187,7 +207,7 @@ class TestMatch(unittest.TestCase):
 
         self.assertEqual(len(result), 4)
         self.assertListEqual(result,
-                             [[self.js_alt, self.john_smith],
+                             [[ self.john_smith, self.js_alt],
                               [self.jane_rae], [self.jrae], [self.jsmith]])
 
     def test_match_email_name(self):
@@ -205,7 +225,7 @@ class TestMatch(unittest.TestCase):
 
         self.assertEqual(len(result), 2)
         self.assertListEqual(result,
-                             [[self.js_alt, self.jsmith, self.john_smith],
+                             [[self.jsmith, self.john_smith, self.js_alt],
                               [self.jane_rae, self.jrae]])
 
     def test_match_email_fast_mode(self):


### PR DESCRIPTION
This PR allows to define when a strict matching is required.

When strict mode is set, only those identities with valid values will be compared during the matching process. For instance, 'email-name' matcher will check whether the email addresses are well-formed or if the name is composed by first and last names. This mode is active by default.

From now on commands `unify` and `load` add an option for deactivating strict matching.