### PR TITLE
[parsing:grimoirelab] Remove `Unknown` enrollments while parsing

### DIFF
--- a/sortinghat/parsing/grimoirelab.py
+++ b/sortinghat/parsing/grimoirelab.py
@@ -253,6 +253,8 @@ class GrimoireLabParser(object):
                 error = "Empty organization name"
                 msg = self.GRIMOIRELAB_INVALID_FORMAT % {'error': error}
                 raise InvalidFormatError(cause=msg)
+            elif name.lower() == 'unknown':
+                continue
 
             # we trust the Organization name included in the identities file
             org = Organization(name=name)

--- a/tests/data/grimoirelab_valid.yml
+++ b/tests/data/grimoirelab_valid.yml
@@ -20,6 +20,7 @@
       end: 2011-12-31
     - organization: Bitergia
       start: 2012-01-01T00:00:00
+    - organization: unknown
   github:
     - sanacl
   irc:
@@ -33,3 +34,6 @@
     is_bot: true
   email:
     - owlbot@bitergia.com
+  enrollments:
+    - organization: Unknown
+      start: 2017-01-01T00:00:00

--- a/tests/test_parser_grimoirelab.py
+++ b/tests/test_parser_grimoirelab.py
@@ -261,6 +261,10 @@ class TestGrimoreLabParser(TestBaseCase):
 
         # Luis Cañas-Díaz
         uid = uids[1]
+
+        # Unknown organization is ignored during the parsing process
+        self.assertEqual(len(uid.enrollments), 2)
+
         rol = uid.enrollments[0]
         self.assertIsInstance(rol, Enrollment)
         self.assertEqual(rol.organization.name, 'GSyC/LibreSoft')
@@ -272,6 +276,12 @@ class TestGrimoreLabParser(TestBaseCase):
         self.assertEqual(rol.organization.name, 'Bitergia')
         self.assertEqual(rol.start, datetime.datetime(2012, 1, 1, 0, 0))
         self.assertEqual(rol.end, datetime.datetime(2100, 1, 1, 0, 0))
+
+        # Owl Bot
+        uid = uids[2]
+
+        # Unknown organization is ignored during the parsing process
+        self.assertEqual(len(uid.enrollments), 0)
 
     def test_not_valid_organizations_stream(self):
         """Check whether it parses invalid organizations files"""


### PR DESCRIPTION
When 'Unknown' organization is found as an enrollment, it will
be removed from the parsed output.

PR related to #104 issue.