### PR TITLE
[cmd:export] Remove trailing whitespaces in JSON files

### DIFF
--- a/sortinghat/cmd/export.py
+++ b/sortinghat/cmd/export.py
@@ -201,7 +201,8 @@ class SortingHatIdentitiesExporter(IdentitiesExporter):
                'uidentities' : uidentities}
 
         return json.dumps(obj, default=self._json_encoder,
-                          indent=4, sort_keys=True)
+                          indent=4, separators=(',', ': '),
+                          sort_keys=True)
 
     def _json_encoder(self, obj):
         """Default JSON encoder"""
@@ -259,7 +260,8 @@ class SortingHatOrganizationsExporter(OrganizationsExporter):
                'uidentities' : {}}
 
         return json.dumps(obj, default=self._json_encoder,
-                          indent=4, sort_keys=True)
+                          indent=4, separators=(',', ': '),
+                          sort_keys=True)
 
     def _json_encoder(self, obj):
         """Default JSON encoder"""


### PR DESCRIPTION
This error is only found in Python 2.7 due to a bug in the
standard library with json.dump() and 'indent' parameter.

The proposed solution works for Python 2.7 and Python 3.x
versions. It forces to use ',' and ': ' as separators in
the JSON file.

More info:
    https://bugs.python.org/issue16333 and
    https://hg.python.org/cpython/rev/78bad589f205

Fixes #103