### PR TITLE
[sortinghat] Upgrade package dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ before_install:
     if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
         pip install MYSQL-python
     else
-        pip install PyMySQL
+        pip install PyMySQL>=0.7.0
     fi
-  - pip install SQLAlchemy==1.0.8
+  - pip install SQLAlchemy>=1.1.15
   - pip install Jinja2
-  - pip install python-dateutil
+  - pip install python-dateutil>=2.6.0
   - pip install pandas==0.18.1
   - pip install coveralls
 

--- a/setup.py
+++ b/setup.py
@@ -108,11 +108,11 @@ setup(name="sortinghat",
         "misc/stackalytics2sh"
       ],
       install_requires=[
-        'PyMySQL',
-        'sqlalchemy>=1.0.0',
+        'PyMySQL>=0.7.0',
+        'sqlalchemy>=1.1.15',
         'jinja2',
         'python-dateutil>=2.6.0',
-        'pandas>=0.17',
+        'pandas==0.18.1',
         'pyyaml>=3.12'
       ],
       cmdclass=cmdclass,

--- a/sortinghat/db/model.py
+++ b/sortinghat/db/model.py
@@ -29,7 +29,7 @@ from sqlalchemy import Column, Boolean, Integer, String, DateTime,\
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declarative_base
-
+from sqlalchemy.types import TypeDecorator, Boolean
 
 # Default dates for periods
 MIN_PERIOD_DATE = datetime.datetime(1900, 1, 1, 0, 0, 0)
@@ -43,6 +43,21 @@ MYSQL_CHARSET = {
 
 
 ModelBase = declarative_base()
+
+
+class CoerceToBool(TypeDecorator):
+    impl = Boolean
+
+    def process_bind_param(self, value, dialect):
+        if type(value) == bool:
+            value = [False, True].index(value)
+        elif type(value) == int:
+            if value not in [0, 1]:
+                raise ValueError
+        else:
+            raise ValueError
+
+        return value
 
 
 class Organization(ModelBase):
@@ -73,7 +88,7 @@ class Domain(ModelBase):
 
     id = Column(Integer, primary_key=True)
     domain = Column(String(128), nullable=False)
-    is_top_domain = Column(Boolean(name='top_domain_check'), default=False)
+    is_top_domain = Column(CoerceToBool(name='top_domain_check'), default=False)
     organization_id = Column(Integer,
                              ForeignKey('organizations.id', ondelete='CASCADE',
                                         onupdate='CASCADE'),
@@ -190,7 +205,7 @@ class Profile(ModelBase):
                   primary_key=True)
     name = Column(String(128))
     email = Column(String(128))
-    is_bot = Column(Boolean(name='is_bot_check'), default=False)
+    is_bot = Column(CoerceToBool(name='is_bot_check'), default=False)
     country_code = Column(String(2),
                           ForeignKey('countries.code', ondelete='CASCADE'))
 


### PR DESCRIPTION
This patch sets the minimum versions of PyMySQL and sqlalchemy to 0.7.0 and 1.1.15, respectively.