### PR TITLE
[db] Fix tables created with invalid collation

### DIFF
--- a/sortinghat/db/database.py
+++ b/sortinghat/db/database.py
@@ -110,7 +110,7 @@ def create_database_engine(user, password, database, host, port):
         driver = 'mysql+pymysql'
 
     url = URL(driver, user, password, host, port, database,
-              query={'charset' : 'utf8'})
+              query={'charset': 'utf8'})
     return create_engine(url, poolclass=QueuePool,
                          pool_size=25, echo=False)
 

--- a/sortinghat/db/model.py
+++ b/sortinghat/db/model.py
@@ -24,7 +24,7 @@ from __future__ import unicode_literals
 
 import datetime
 
-from sqlalchemy import Column, Boolean, Integer, String, DateTime,\
+from sqlalchemy import Column, Integer, String, DateTime,\
     ForeignKey, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -37,7 +37,7 @@ MAX_PERIOD_DATE = datetime.datetime(2100, 1, 1, 0, 0, 0)
 
 # Default charset and collation
 MYSQL_CHARSET = {
-    'mysql_charset': 'utf8',
+    'mysql_default_charset': 'utf8',
     'mysql_collate': 'utf8_unicode_ci'
 }
 


### PR DESCRIPTION
In some random situations SortingHat tables appear with an invalid collation. This is related to a wrong generation of the DDL table statement by SqlAlchemy, which may randomly prepend the collation information (mysql_collate) to the charset one (mysql_charset), causing the former to be ignored. Changing mysql_charset to mysql_default_charset fixes the problem.

To ensure the effectiveness of the fix, a shell script, which creates n SortingHat dbs and checks the collation, is provided below.

```
#!/bin/bash

db_name=test_sorting_hat
user=root
pwd=root
output=/tmp/sorting_hat
loops=20

for (( i = 1 ; i <= ${loops} ; i += 1 )) ; do
	sortinghat -u ${user} -p${pwd} --host localhost --port 3306 -d ${db_name} init ${db_name}
	mysql -u ${user} -p${pwd} ${db_name} -e "show create table identities;" > ${output}_$i.txt

	if grep -q "COLLATE=utf8_unicode_ci" ${output}_$i.txt; then 
		echo "test " "$i" " ok" 
	else 
		echo "test " "$i" " wrong!" 
	fi 

	mysql -u ${user} -p${pwd} -e "drop database ${db_name};" 
done
```