### PR TITLE
[init] Add option for reusing database

### DIFF
--- a/sortinghat/exceptions.py
+++ b/sortinghat/exceptions.py
@@ -40,7 +40,7 @@ CODE_LOAD_ERROR = 7
 CODE_MATCHER_NOT_SUPPORTED_ERROR = 8
 CODE_NOT_FOUND_ERROR = 9
 CODE_VALUE_ERROR = 10
-
+CODE_DATABASE_EXISTS = 11
 
 class BaseError(Exception):
     """Base class error.
@@ -90,7 +90,14 @@ class DatabaseError(BaseError):
     """Exception raised when a database error occurs"""
 
     message = "%(error)s (err: %(code)s)"
-    code = CODE_DATABASE_ERROR
+    code = CODE_DATABASE_EXISTS
+
+
+class DatabaseExists(BaseError):
+    """Exception raised when trying to create a database and it already exists"""
+
+    message = "%(error)s (err: %(code)s)"
+    code = CODE_DATABASE_EXISTS
 
 
 class InvalidDateError(BaseError):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1457,7 +1457,8 @@ class TestDeleteEnrollment(TestAPICaseBase):
 
         with self.db.connect() as session:
             enrollments = session.query(Enrollment).join(Organization).\
-                    filter(Organization.name == 'Example').all()
+                    filter(Organization.name == 'Example').\
+                    order_by(Enrollment.start).all()
             self.assertEqual(len(enrollments), 2)
 
             self.assertEqual(enrollments[0].start, datetime.datetime(1900, 1, 1))

--- a/tests/test_cmd_init.py
+++ b/tests/test_cmd_init.py
@@ -36,7 +36,8 @@ from sortinghat import api
 from sortinghat.command import CMD_SUCCESS
 from sortinghat.cmd.init import Init
 from sortinghat.db.database import Database
-from sortinghat.exceptions import CODE_DATABASE_ERROR, CODE_VALUE_ERROR
+from sortinghat.exceptions import CODE_DATABASE_ERROR, CODE_DATABASE_EXISTS, \
+                                    CODE_VALUE_ERROR
 
 
 DB_ACCESS_ERROR = r".+Access denied for user '%(user)s'@'localhost'"
@@ -52,8 +53,9 @@ class TestInitCaseBase(unittest.TestCase):
         if not hasattr(sys.stdout, 'getvalue') and not hasattr(sys.stderr, 'getvalue'):
             self.fail('This test needs to be run in buffered mode')
 
-        # Create a temporal name for the registry
+        # Create temporal names for the registry
         self.name = 'tmp' + uuid.uuid4().hex
+        self.name_reuse = 'tmp' + uuid.uuid4().hex
 
         config = configparser.ConfigParser()
         config.read(CONFIG_FILE)
@@ -61,16 +63,14 @@ class TestInitCaseBase(unittest.TestCase):
         # Create command
         self.kwargs = {'user' : config['Database']['user'],
                        'password' : config['Database']['password'],
-                       'database' : self.name,
                        'host' : config['Database']['host'],
                        'port' : config['Database']['port']}
-        self.cmd = Init(**self.kwargs)
+        self.cmd = Init(database=self.name, **self.kwargs)
+        self.cmd_reuse = Init(database=self.name_reuse, **self.kwargs)
 
     def tearDown(self):
-        Database.drop(self.kwargs['user'], self.kwargs['password'],
-                      self.name, self.kwargs['host'],
-                      self.kwargs['port'])
-
+        Database.drop(database=self.name, **self.kwargs)
+        Database.drop(database=self.name_reuse, **self.kwargs)
 
 class TestInitCommand(TestInitCaseBase):
     """Unit tests for init command"""
@@ -81,8 +81,7 @@ class TestInitCommand(TestInitCaseBase):
         code = self.cmd.run(self.name)
         self.assertEqual(code, CMD_SUCCESS)
 
-        db = Database(self.kwargs['user'], self.kwargs['password'], self.name,
-                      self.kwargs['host'], self.kwargs['port'])
+        db = Database(database=self.name, **self.kwargs)
         self.assertIsInstance(db, Database)
 
         # Check if the list of countries was loaded
@@ -114,13 +113,22 @@ class TestInitCommand(TestInitCaseBase):
         self.assertEqual(code1, CMD_SUCCESS)
 
         code2 = self.cmd.run(self.name)
-        self.assertEqual(code2, CODE_DATABASE_ERROR)
+        self.assertEqual(code2, CODE_DATABASE_EXISTS)
 
         # Context added to catch deprecation warnings raised on Python 3
         with warnings.catch_warnings(record=True):
             output = sys.stderr.getvalue().strip()
             self.assertRegexpMatches(output,
                                      DB_EXISTS_ERROR % {'database' : self.name})
+
+    def test_existing_db_reuse(self):
+        """Check that no error is returned when creating the registry twice"""
+
+        code1 = self.cmd_reuse.run('--reuse', self.name_reuse)
+        self.assertEqual(code1, CMD_SUCCESS)
+
+        code2 = self.cmd_reuse.run('--reuse', self.name_reuse)
+        self.assertEqual(code2, CMD_SUCCESS)
 
 
 class TestInitialize(TestInitCaseBase):
@@ -147,7 +155,8 @@ class TestInitialize(TestInitCaseBase):
                   'password' : 'nopassword',
                   'database' : None,
                   'host' : 'localhost',
-                  'port' : '3306'}
+                  'port' : '3306',
+                  'reuse': False}
 
         cmd = Init(**kwargs)
         code = cmd.initialize(self.name)
@@ -166,13 +175,25 @@ class TestInitialize(TestInitCaseBase):
         self.assertEqual(code1, CMD_SUCCESS)
 
         code2 = self.cmd.initialize(self.name)
-        self.assertEqual(code2, CODE_DATABASE_ERROR)
+        self.assertEqual(code2, CODE_DATABASE_EXISTS)
 
         # Context added to catch deprecation warnings raised on Python 3
         with warnings.catch_warnings(record=True):
             output = sys.stderr.getvalue().strip()
             self.assertRegexpMatches(output,
                                      DB_EXISTS_ERROR % {'database' : self.name})
+
+    def test_existing_db_reuse(self):
+        """Check reusing works as intended when registriy is "created" twice"""
+
+        code1 = self.cmd_reuse.initialize(self.name_reuse, reuse=True)
+        self.assertEqual(code1, CMD_SUCCESS)
+
+        code2 = self.cmd_reuse.initialize(self.name_reuse, reuse=True)
+        self.assertEqual(code2, CMD_SUCCESS)
+
+        code3 = self.cmd_reuse.initialize(self.name, reuse=True)
+        self.assertEqual(code3, CMD_SUCCESS)
 
     def test_invalid_name_error(self):
         """Check if it returns an error when an invalid database name is given"""

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -28,9 +28,9 @@ import unittest
 if not '..' in sys.path:
     sys.path.insert(0, '..')
 
-from sortinghat.exceptions import BaseError, AlreadyExistsError, BadFileFormatError,\
-    DatabaseError, InvalidDateError, InvalidFormatError, LoadError,\
-    MatcherNotSupportedError, NotFoundError
+from sortinghat.exceptions import BaseError, AlreadyExistsError, \
+    BadFileFormatError, DatabaseError, DatabaseExists, InvalidDateError, \
+    InvalidFormatError, LoadError, MatcherNotSupportedError, NotFoundError
 
 
 # Mock classes to test BaseError class
@@ -129,6 +129,27 @@ class TestDatabaseError(unittest.TestCase):
 
         kwargs = {'code' : 1049}
         self.assertRaises(KeyError, DatabaseError, **kwargs)
+
+
+class TestDatabaseExists(unittest.TestCase):
+
+    def test_message(self):
+        """Make sure that prints the correct error"""
+
+        e = DatabaseExists(error="Database exists 'mydb'", code=1049)
+        self.assertEqual("Database exists 'mydb' (err: 1049)", str(e))
+
+    def test_no_args(self):
+        """Check whether it raises a KeyError exception when
+        required parameters are not given"""
+        kwargs = {}
+        self.assertRaises(KeyError, DatabaseExists, **kwargs)
+
+        kwargs = {'error' : "Database existis 'mydb'"}
+        self.assertRaises(KeyError, DatabaseExists, **kwargs)
+
+        kwargs = {'code' : 1049}
+        self.assertRaises(KeyError, DatabaseExists, **kwargs)
 
 
 class TestInvalidDateError(unittest.TestCase):


### PR DESCRIPTION
Really, for raising a new exception when intending to create a new database (using init). And a new option to Init, reuse, that will not trigger printing the message about "error creating database" which appears now every time you call Init.