### PR TITLE
[gitdm2sh] Set option to ignore invalid email addresses

### DIFF
--- a/misc/gitdm2sh
+++ b/misc/gitdm2sh
@@ -41,8 +41,9 @@ def main():
     args = parse_args()
 
     try:
+        email_validation = not args.no_email_validation
         parser = parse_gitdm_files(args.aliases, args.email_employer,
-                                   args.domain_employer, args.source)
+                                   args.domain_employer, args.source, email_validation)
     except (IOError, UnicodeDecodeError, InvalidFormatError) as e:
         raise RuntimeError(str(e))
 
@@ -75,12 +76,15 @@ def parse_args():
     parser.add_argument('-o', '--outfile', nargs='?', type=argparse.FileType('w'),
                         default=sys.stdout,
                         help='Sorting Hat JSON output filename')
+    parser.add_argument('--no-email-validation', dest='no_email_validation',
+                        action='store_true',
+                        help="do not email addresses validation")
 
     return parser.parse_args()
 
 
 def parse_gitdm_files(aliases, email_to_employer,
-                      domain_to_employer, source):
+                      domain_to_employer, source, email_validation):
     """Parse Gitdm files"""
 
     a = None
@@ -97,7 +101,8 @@ def parse_gitdm_files(aliases, email_to_employer,
     parser = GitdmParser(aliases=a,
                          email_to_employer=ee,
                          domain_to_employer=de,
-                         source=source)
+                         source=source,
+                         email_validation=email_validation)
     return parser
 
 

--- a/tests/data/gitdm_email_to_employer_invalid.txt
+++ b/tests/data/gitdm_email_to_employer_invalid.txt
@@ -1,0 +1,9 @@
+#
+# Gitdm enrollments example
+#
+
+jsmith.example.com	Example Company		# John Smith
+jdoe$example.com	Example Company		# John Doe
+jsmith!example.com	Bitergia < 2015-01-01	# John Smith - Bitergia
+jrae-example-net	Bitergia
+john_doeexample	LibreSoft

--- a/tests/test_parser_gitdm.py
+++ b/tests/test_parser_gitdm.py
@@ -143,6 +143,38 @@ class TestGidmParser(TestBaseCase):
 
         self.assertEqual(len(uid.enrollments), 0)
 
+    def test_email_validation(self):
+        aliases = self.read_file('data/gitdm_email_aliases_valid.txt')
+        email_to_employer = self.read_file('data/gitdm_email_to_employer_invalid.txt')
+
+        with self.assertRaises(InvalidFormatError):
+            GitdmParser(aliases=aliases,
+                        email_to_employer=email_to_employer,
+                        source='unknown', email_validation=True)
+
+    def test_supress_email_validation(self):
+        email_to_employer = self.read_file('data/gitdm_email_to_employer_invalid.txt')
+
+        parser = GitdmParser(email_to_employer=email_to_employer,
+                             source='unknown', email_validation=False)
+
+        uids = parser.identities
+        self.assertEqual(len(uids), 5)
+
+        expected_emails = ['jsmith.example.com', 'jdoe$example.com', 'jsmith!example.com',
+                           'jrae-example-net', 'john_doeexample']
+
+        for uid in uids:
+            id = uid.identities[0]
+            self.assertIsInstance(uid, UniqueIdentity)
+            self.assertIsInstance(id, Identity)
+            self.assertIn(uid.uuid, expected_emails)
+            self.assertEqual(uid.uuid, id.email)
+            self.assertEqual(id.name, None)
+            self.assertEqual(id.username, None)
+            self.assertEqual(id.source, 'unknown')
+            self.assertEqual(id.uuid, None)
+
     def test_enrollments_parser(self):
         aliases = self.read_file('data/gitdm_email_aliases_valid.txt')
         email_to_employer = self.read_file('data/gitdm_email_to_employer_valid.txt')


### PR DESCRIPTION
This PR targets issue #119 . In a nutshell, when email_validation is set to False, invalid email addresses will not make the parser fail. By default, email validation is active.